### PR TITLE
Reuse of already defined type alias in UserDefaults.swift

### DIFF
--- a/Palau/UserDefaults.swift
+++ b/Palau/UserDefaults.swift
@@ -39,8 +39,8 @@ import Foundation
 public struct PalauDefaults {
 
   /// The underlying defaults
-  public static var defaults: NSUserDefaults {
-    return NSUserDefaults.standardUserDefaults()
+  public static var defaults: NSUD {
+    return NSUD.standardUserDefaults()
   }
 
   /// Pure - will always return the provided value


### PR DESCRIPTION
NSUD == NSUserDefaults
