### PR TITLE
Travis CI Shield IO badge should be pointing to Master Branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/symentis/Palau/master/Resources/palau-logo.png">
 </p>
 
-[![Build Status](https://travis-ci.org/symentis/Palau.svg)](https://travis-ci.org/symentis/Palau)
+[![Build Status](https://travis-ci.org/symentis/Palau.svg?branch=master)](https://travis-ci.org/symentis/Palau)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Palau.svg)](https://img.shields.io/cocoapods/v/Palau)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/cocoapods/p/Palau.svg?style=flat)](http://cocoadocs.org/docsets/Palau)


### PR DESCRIPTION
We shouldn't show broken branches on the README only the Master
