### PR TITLE
Set app extension only API usage for tvOS target

### DIFF
--- a/Palau.xcodeproj/project.pbxproj
+++ b/Palau.xcodeproj/project.pbxproj
@@ -510,6 +510,7 @@
 		286A51461CCFBC5900F02082 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -530,6 +531,7 @@
 		286A51471CCFBC5900F02082 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -667,6 +669,7 @@
 		28ED2A9F1CD206500066531F /* ReleaseTest */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
The main Palau framework target takes advantage of the "Allow app extension API only" feature but the tvOS target does not.
